### PR TITLE
route Validation remove encodeXML

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -28,7 +28,7 @@ const { NotFound } = httpErrors
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 const SERVICE_1_1 = 'cuahsi_1_1'
-const ORG_REGEXP_STR = '^[A-Za-z][A-Za-z0-9-_]{2,}[A-Za-z0-9]$'
+const ORG_REGEXP_STR = '^[A-Za-z][A-Za-z0-9-_]{1,}[A-Za-z0-9]$'
 
 export default async logger => {
   const app = {}

--- a/src/soap/serializers/common.js
+++ b/src/soap/serializers/common.js
@@ -132,9 +132,7 @@ export function unitsType(data) {
       ? `<unitType>${encodeXML(data.UnitsType)}</unitType>`
       : '') +
     (data.UnitsAbbreviation
-      ? `<unitAbbreviation>${encodeXML(
-          data.UnitsAbbreviation
-        )}</unitAbbreviation>`
+      ? `<unitAbbreviation>${data.UnitsAbbreviation}</unitAbbreviation>`
       : '') +
     (data.UnitsID ? `<unitCode>${encodeXML(data.UnitsID)}</unitCode>` : '')
   )

--- a/src/soap/serializers/site.js
+++ b/src/soap/serializers/site.js
@@ -35,11 +35,11 @@ export function siteInfoType({ organizationRefsMap, refsMap, station }) {
     refsMap && refsMap.get('his.odm.sites.LocalProjection.CVSRSName')
 
   return (
-    `<siteName>${encodeXML(station.name)}</siteName>` +
+    `<siteName>${station.name}</siteName>` +
     (siteCode
-      ? `<siteCode network="${encodeXML(
+      ? `<siteCode network="${
           networkName || 'dendra'
-        )}" siteID="${siteId}">${encodeXML(siteCode)}</siteCode>`
+        }" siteID="${siteId}">${encodeXML(siteCode)}</siteCode>`
       : '') +
     (station.geo && station.geo.type === 'Point'
       ? '<geoLocation>' +
@@ -60,25 +60,15 @@ export function siteInfoType({ organizationRefsMap, refsMap, station }) {
         }` +
         '</geoLocation>'
       : '') +
-    (elevationM ? `<elevation_m>${encodeXML(elevationM)}</elevation_m>` : '') +
-    (verticalDatum
-      ? `<verticalDatum>${encodeXML(verticalDatum)}</verticalDatum>`
-      : '') +
-    (county
-      ? `<siteProperty name="County">${encodeXML(county)}</siteProperty>`
-      : '') +
-    (state
-      ? `<siteProperty name="State">${encodeXML(state)}</siteProperty>`
-      : '') +
+    (elevationM ? `<elevation_m>${elevationM}</elevation_m>` : '') +
+    (verticalDatum ? `<verticalDatum>${verticalDatum}</verticalDatum>` : '') +
+    (county ? `<siteProperty name="County">${county}</siteProperty>` : '') +
+    (state ? `<siteProperty name="State">${state}</siteProperty>` : '') +
     (comments
-      ? `<siteProperty name="Site Comments">${encodeXML(
-          comments
-        )}</siteProperty>`
+      ? `<siteProperty name="Site Comments">${comments}</siteProperty>`
       : '') +
     (posAccuracyM
-      ? `<siteProperty name="PosAccuracy_m">${encodeXML(
-          posAccuracyM
-        )}</siteProperty>`
+      ? `<siteProperty name="PosAccuracy_m">${posAccuracyM}</siteProperty>`
       : '')
   )
 }


### PR DESCRIPTION
### Changes

- **Routes Validation**
         Before: organization slug must have minimum 4 character. Organization name `French River Connection Water Quality Monitoring`'s slug is `frc`, it is not returning correct response.

- **Remove some encodeXML**
    for eg: 
    unitAbbreviation: `%` the result coming as `&#x2030;`
    That is why I removed encodeXML.
